### PR TITLE
fix lifetime of generated crl

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ This role must run in same operation on
 Versions
 ========
 
+* `2.1.1` --- fix lifetime of generated crl
 * `2.1.0` --- all certificates on recipient is now owned by user and group `easyrsa`
 * `2.0.0` --- added mutex handling to easyrsa script to parallelize
 * `1.1.5` --- changed `easyrsa_ca_ca_expire` defaults

--- a/tasks/configure-ca-server.yml
+++ b/tasks/configure-ca-server.yml
@@ -57,7 +57,7 @@
   when: not ca_crt_file.stat.exists
 
 - name: rebuild crl always
-  command: "{{ easyrsa_command }} {{ easyrsa_ca_options }} --days='{{ easyrsa_ca_ca_expire }}' --req-cn=\\'{{ easyrsa_ca_cn }}\\' gen-crl"
+  command: "{{ easyrsa_command }} {{ easyrsa_ca_options }} --days='{{ easyrsa_ca_crl_days }}' --req-cn=\\'{{ easyrsa_ca_cn }}\\' gen-crl"
   changed_when: false
   args:
     chdir: "{{ easyrsa_ca_dir }}"


### PR DESCRIPTION
Use correct variable when generating CRLs.

Bump to version 2.1.1.